### PR TITLE
README edit: rolldown_style_default() not exported

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ output:
 
 ```{r echo = FALSE}
 # include this code block in the beginning to specify a style
-rolldown::rolldown_style_default()
+rolldown:::rolldown_style_default()
 ```
 
 # Level-One


### PR DESCRIPTION
The line `rolldown::rolldown_style_default()` errors out because `rolldown_style_default()` is not an exported function.

I'm not sure if the true bug is that this line should read `rolldown:::rolldown_style_default()` (which works!) or if `rolldown_style_default()` is meant to be exported. This suggestion just changes the former so that the example works with the code as-is.

Thanks so much for working on this! It's such a fun format, and I'm very excited to start using it.